### PR TITLE
Should specify protocol to avoid security warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
         </li>
         <li class="point social">
           <small>Round-trip downstairs to the Firkin to get some</small>
-          <div><a href="//www.firkinpubs.com/firkinatthetannery/drinks">beer</a> / soda</div>
+          <div><a href="http://www.firkinpubs.com/firkinatthetannery/drinks">beer</a> / soda</div>
         </li>
         <li class="point">
           <time>12:00a</time>


### PR DESCRIPTION
When I follow the link to 'beer' on the live site, using Chrome on OS X, I receive a privacy error because when the protocol is not specified the browser tries https which the firkin site doesn't do and then like, all our datas are leaking out and stuff oh no!
